### PR TITLE
Fix#6

### DIFF
--- a/src/messages/Error.cpp
+++ b/src/messages/Error.cpp
@@ -6,15 +6,9 @@
  */
 #include "Error.hpp"
 
-#include <utility>
-
 namespace messages {
     Error::Error() {
+        CLASS(Error)
         PROPERTY(message)
     }
-
-    auto Error::getMessageName() const -> std::string {
-        return "Error";
-    }
-
 }

--- a/src/messages/Error.hpp
+++ b/src/messages/Error.hpp
@@ -14,8 +14,6 @@ namespace messages {
         Error();
 
         std::string message;
-
-        [[nodiscard]] auto getMessageName() const -> std::string override;
     };
 }
 

--- a/src/messages/JoinRequest.cpp
+++ b/src/messages/JoinRequest.cpp
@@ -8,6 +8,7 @@
 
 namespace messages {
     JoinRequest::JoinRequest() {
+        CLASS(JoinRequest)
         PROPERTY(lobbyName)
     }
 }

--- a/src/messages/Message.cpp
+++ b/src/messages/Message.cpp
@@ -33,6 +33,7 @@ namespace messages {
         for (const auto &[_, isInstance, name] : classes) {
             if (isInstance(this)) {
                 json["name"] = name;
+                break;
             }
         }
 

--- a/src/messages/Message.hpp
+++ b/src/messages/Message.hpp
@@ -14,6 +14,12 @@
 
 #include <nlohmann/json.hpp>
 
+#define CLASS(c) addClass( \
+    std::make_shared<c>, \
+    [] (const Message *msg) { return dynamic_cast<const c*>(msg) != nullptr;}, \
+    #c \
+);
+
 #define PROPERTY(p) addProperty( \
     [this] (const nlohmann::json &j) {this->p = j.get<decltype(this->p)>();}, \
     [this] () {return this->p;}, \
@@ -23,9 +29,14 @@
 namespace messages {
     class Message {
             using json = nlohmann::json;
+
             using PropertySetter = std::function<void(const nlohmann::json &)>;
             using PropertyGetter = std::function<nlohmann::json()>;
             using PropertyInfo = std::tuple<PropertySetter, PropertyGetter, std::string>;
+
+            using Factory = std::function<std::shared_ptr<Message>()>;
+            using IsInstance = std::function<bool(const Message*)>;
+            using ClassInfo = std::tuple<Factory, IsInstance, std::string>;
         public:
             Message() = default;
 
@@ -37,19 +48,21 @@ namespace messages {
 
             auto operator=(Message &&message) = delete;
 
-            [[nodiscard]] virtual auto getMessageName() const -> std::string = 0;
-
             [[nodiscard]] auto toJson() const -> nlohmann::json;
 
             static auto fromJson(const nlohmann::json &json) -> std::shared_ptr<Message>;
 
+            virtual ~Message() = default;
+
         protected:
             void addProperty(const PropertySetter &setter, const PropertyGetter &getter, const std::string &name);
+
+            static void addClass(const Factory &factory, const IsInstance &isInstance, const std::string &name);
 
         private:
             std::vector<PropertyInfo> properties;
 
-
+            static std::vector<ClassInfo> classes;
     };
 }
 


### PR DESCRIPTION
Gibt jetzt eine `addClass` Methode ähnlich der `addProperty` Methode. Außerdem gibt es ein entsprechendes Makro dass die Funktion korrekt aufruft. Dafür ist das `CASE` Makro nicht mehr notwendig und die `Message` braucht kein Wissen über alle Message Typen, da die sich selber registrieren.