### PR TITLE
FixFix#6

### DIFF
--- a/src/messages/Error.cpp
+++ b/src/messages/Error.cpp
@@ -7,8 +7,9 @@
 #include "Error.hpp"
 
 namespace messages {
+    CLASS(Error)
+
     Error::Error() {
-        CLASS(Error)
         PROPERTY(message)
     }
 }

--- a/src/messages/JoinRequest.cpp
+++ b/src/messages/JoinRequest.cpp
@@ -7,8 +7,9 @@
 #include "JoinRequest.hpp"
 
 namespace messages {
+    CLASS(JoinRequest)
+
     JoinRequest::JoinRequest() {
-        CLASS(JoinRequest)
         PROPERTY(lobbyName)
     }
 }

--- a/src/messages/Message.cpp
+++ b/src/messages/Message.cpp
@@ -13,15 +13,16 @@ namespace messages {
         properties.emplace_back(setter, getter, name);
     }
 
-    void
+    bool
     Message::addClass(const Message::Factory &factory, const Message::IsInstance &isInstance, const std::string &name) {
         for (const auto &[f, i, className] : classes) {
             if (className == name) {
-                return;
+                return false;
             }
         }
 
         classes.emplace_back(factory, isInstance, name);
+        return true;
     }
 
     auto Message::toJson() const -> nlohmann::json {

--- a/src/messages/Message.hpp
+++ b/src/messages/Message.hpp
@@ -14,7 +14,7 @@
 
 #include <nlohmann/json.hpp>
 
-#define CLASS(c) addClass( \
+#define CLASS(c) static auto _tmp_ = Message::addClass( \
     std::make_shared<c>, \
     [] (const Message *msg) { return dynamic_cast<const c*>(msg) != nullptr;}, \
     #c \
@@ -24,7 +24,8 @@
     [this] (const nlohmann::json &j) {this->p = j.get<decltype(this->p)>();}, \
     [this] () {return this->p;}, \
     #p \
-);
+); \
+_tmp_ = false;
 
 namespace messages {
     class Message {
@@ -54,10 +55,9 @@ namespace messages {
 
             virtual ~Message() = default;
 
+            static bool addClass(const Factory &factory, const IsInstance &isInstance, const std::string &name);
         protected:
             void addProperty(const PropertySetter &setter, const PropertyGetter &getter, const std::string &name);
-
-            static void addClass(const Factory &factory, const IsInstance &isInstance, const std::string &name);
 
         private:
             std::vector<PropertyInfo> properties;


### PR DESCRIPTION
Fix#6 hat die Klasse erst im Konstruktor registriert. D.h. eine Klasse kann erst deserialisiert werden wenn sie einmal konstruiert wurde, problematisch bei Klassen die nur empfangen werden. Daher wurde das `CLASS` Makro jetzt so erweitert, dass das eine statische Variable füllt. Dadurch kann eine Funktion im statischen Kontext, also vor der `main` aufgerufen werden.

Das geht aber nur da die statische Variable auch existiert, um Warnings/Fehler zu vermeiden wird die Variable dann im `PROPERTY` Makro auch genutzt. Hat den netten Nebeneffekt, dass es zu einem Compiler Fehler kommt, falls `CLASS` nicht aufgerufen wurde.